### PR TITLE
Call times based on wav file for pagers/intercoms

### DIFF
--- a/dss_voip/Dockerfile
+++ b/dss_voip/Dockerfile
@@ -19,7 +19,8 @@ RUN apk add --no-cache \
     wget=1.20.3-r0 \
     sox \
     pjsua \
-    screen
+    screen \
+    bc
     
 # Build arguments
 ARG BUILD_ARCH
@@ -38,7 +39,7 @@ LABEL \
     org.label-schema.description="VoIP Notifier for HomeAssistant" \
     org.label-schema.build-date=${BUILD_DATE} \
     org.label-schema.name="Addon VoIP for ${BUILD_ARCH}" \
-    org.label-schema.schema-version="3.3.2" \
+    org.label-schema.schema-version="3.3.3" \
     org.label-schema.url="https://sdesalve.it" \
     org.label-schema.usage="https://github.com/sdesalve/hassio-addons/dss_voip/README.md" \
     org.label-schema.vcs-ref=${BUILD_REF} \

--- a/dss_voip/README.md
+++ b/dss_voip/README.md
@@ -88,8 +88,8 @@ Set optional custom command's line options for output file. For reference see [S
 
 #### Option `max_call_time` (Optional)
 
-Set maximum call duration in seconds. Accept value between 10 and 120 seconds. Default value if this option is not specified is 50 seconds.
-The timer starts working after a call is initiated and is not related to the call status.
+Set maximum call duration in seconds. Accept value between 10 and 120 seconds, but must be in single quotes. Default value if this option is not specified is 50 seconds.  If set to '-1' max_call_time is set to the length of the wav file being read.  This setting is to accommodate auto-answering systems like pagers and intercoms.  Be advised that many such systems will present insert a short beep at the start of the page.  It may be adventitious to pad some small amount of silence at that start of the wav file.  See `call_duration` below.
+The timer starts working after a call is initiated and is not related to the call status.  
 
 #### Option `platform_tts` (Optional)
 
@@ -229,7 +229,7 @@ Write here a valid URL of a MP3 file that will be played to the attendee. If nor
 
 #### Option `call_duration` (Optional)
 
-Set maximum call duration in seconds. Be aware that timer starts running after a call is initiated and is not related to the call status. If this option is specified `max_call_time` will be overwrited for service invocation.
+Set maximum call duration in seconds. Be aware that timer starts running after a call is initiated and is not related to the call status. If this option is specified `max_call_time` will be overwrited for service invocation.  If set to '-1' this will set the call duration to the length of the wav file.  See `max_call_time` above.
 
 
 ## Support

--- a/dss_voip/config.json
+++ b/dss_voip/config.json
@@ -1,6 +1,6 @@
 {
   "name": "DSS VoIP Notifier",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "slug": "dss_voip",
   "url": "https://github.com/sdesalve/hassio-addons/tree/master/dss_voip",
   "description": "VoIP Notifier for HomeAssistant",
@@ -28,7 +28,7 @@
       "username": "str?",
       "password": "str?"
     },
-    "max_call_time": "int(10,120)?",
+    "max_call_time": "str?",
     "platform_tts": "str?",
     "pjsua_custom_options": "str?",
     "sox_custom_options_input_file": "str?",

--- a/dss_voip/rootfs/etc/services.d/stdin/run
+++ b/dss_voip/rootfs/etc/services.d/stdin/run
@@ -100,6 +100,7 @@ if [ "$SIP_PARAMETERS" -gt "0" ]; then
       echo "--play-file /etc/dss_autoanswer.wav"           >> /share/dss_voip/dss_autoanswer.conf
       echo "--duration 30"                                 >> /share/dss_voip/dss_autoanswer.conf
       echo "--auto-answer 200"                             >> /share/dss_voip/dss_autoanswer.conf
+      
       echo "--auto-loop"                                   >> /share/dss_voip/dss_autoanswer.conf
       echo "--max-calls 5"                                 >> /share/dss_voip/dss_autoanswer.conf
 
@@ -157,6 +158,14 @@ if [ "$SIP_PARAMETERS" -gt "0" ]; then
    MAX_CALL_TIME=$(bashio::config 'max_call_time | length')
    if [ "$MAX_CALL_TIME" -gt "0" ]; then 
       MAX_CALL_TIME_VALUE=$(bashio::config 'max_call_time')
+
+      if [ "$MAX_CALL_TIME_VALUE" -gt "120" ]; then
+        MAX_CALL_TIME_VALUE=120
+      elif [ "$MAX_CALL_TIME_VALUE" == "-1" ]; then
+        MAX_CALL_TIME_VALUE=-1
+      elif [ "$MAX_CALL_TIME_VALUE" -lt "10" ]; then
+        MAX_CALL_TIME_VALUE=10
+      fi
       echo "MAX_CALL_TIME = \
              '$MAX_CALL_TIME'"                             >> /share/dss_voip/dss_pjsua.log
       bashio::log.yellow "MAX_CALL_TIME = '$MAX_CALL_TIME_VALUE'"
@@ -164,7 +173,11 @@ if [ "$SIP_PARAMETERS" -gt "0" ]; then
       MAX_CALL_TIME_VALUE=50
    fi
    
-   echo "--duration $MAX_CALL_TIME_VALUE"                  >> /share/dss_voip/dss_pjsua.conf
+   if [ "$MAX_CALL_TIME_VALUE" == "-1" ]; then
+     echo "--duration 120"                                 >> /share/dss_voip/dss_pjsua.conf
+   else 
+     echo "--duration $MAX_CALL_TIME_VALUE"                >> /share/dss_voip/dss_pjsua.conf
+   fi
    echo ""                                                 >> /share/dss_voip/dss_pjsua.conf
    echo "sip_parameters = '$SIP_PARAMETERS_VALUE'"         >> /share/dss_voip/dss_pjsua.log
    
@@ -304,10 +317,21 @@ while read -r msg; do
             bashio::log.green "Audio succesfully converted..."
             bashio::log.green "Starting SIP Client and calling '$CALL_SIP_URI_VALUE'..."
 
-
             if [ "$CALL_DURATION_VALUE" -gt "0" ]; then
                MAX_CALL_TIME_VALUE="$CALL_DURATION_VALUE"
-            fi
+            elif [ "$CALL_DURATION_VALUE" == "-1" ]; then
+               MAX_CALL_TIME_VALUE=-1
+            fi 
+
+            if [ "$MAX_CALL_TIME_VALUE" == "-1" ]; then 
+               MAX_CALL_TIME_VALUE=$(soxi -d /share/dss_voip/dss_message_tts.wav | awk -F: '{ print ($1 * 3600) + ($2 * 60) + $3 }')
+               if [ $(echo "$MAX_CALL_TIME_VALUE < 1" | bc) -eq 1 ]; then
+                 # Sanity check, might need to increase this value, but we don't want pager/intercom calls stacking up 
+                 # in the PBX's queue.
+                 MAX_CALL_TIME_VALUE=1
+               fi
+            fi 
+
             bashio::log.green "This call will be terminated after '$MAX_CALL_TIME_VALUE' seconds."
 
             ( sleep $MAX_CALL_TIME_VALUE; echo h; sleep 0.5; echo q ) | ( pjsua --app-log-level=3 --config-file '/share/dss_voip/dss_pjsua.conf' $CALL_SIP_URI_VALUE 2> /share/dss_voip/dss_pjsua.log) 


### PR DESCRIPTION
This change should allow for better call times where the remote extension is a pager/intercom pool.

Had to change typing from integer to string for max_call_time, as bash can not do numerical comparisons on -1